### PR TITLE
Replace rindex(3) with strrchr(3)

### DIFF
--- a/ltrace-elf.c
+++ b/ltrace-elf.c
@@ -41,7 +41,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <unistd.h>
 
 #include "backend.h"
@@ -1219,7 +1218,7 @@ read_module(struct library *lib, struct process *proc,
 			goto fail;
 		library_set_soname(lib, soname, 1);
 	} else {
-		const char *soname = rindex(lib->pathname, '/');
+		const char *soname = strrchr(lib->pathname, '/');
 		if (soname != NULL)
 			soname += 1;
 		else


### PR DESCRIPTION
This gets rid of a legacy function and improves portability, see
http://pubs.opengroup.org/onlinepubs/009695399/functions/rindex.html

Specifically fixes an Android build failure.
